### PR TITLE
fix(styles): Rename conflicting class name in global CSS

### DIFF
--- a/Frontend/src/features/media/mediaDetailsCOMPONENTS/api-recommendation/api-recommendation.component.html
+++ b/Frontend/src/features/media/mediaDetailsCOMPONENTS/api-recommendation/api-recommendation.component.html
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 } 
 @else {
     @if (recommendations && recommendations.recommendations) {
-        <ul class="cardContainer">
+        <ul class="recommendationCardContainer">
             @for (rec of recommendations.recommendations; track $index) {
                 <li class="recCard" (click)="onClickRecommendation(rec.id, rec.media_type === 'movie')" [pTooltip]="rec.name">
                     <img [alt]="'Poster zu ' + rec.name" [src]="POSTER_PATH + rec.poster_path">

--- a/Frontend/src/features/media/mediaDetailsCOMPONENTS/recommendation-card/recommendation-card.component.html
+++ b/Frontend/src/features/media/mediaDetailsCOMPONENTS/recommendation-card/recommendation-card.component.html
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 }
 
 @if (inpRecommendationsList().length > 0) {
-    <ul class="cardContainer">
+    <ul class="recommendationCardContainer">
         @for (recommendation of inpRecommendationsList(); track $index) {
             <li 
                 class="recCard" 

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -1627,7 +1627,7 @@ p {
     color: #10b981 !important;
 }
 
-.cardContainer {
+.recommendationCardContainer {
     list-style: none;
     padding: 0;
     gap: 2rem;


### PR DESCRIPTION
Es wurde in Frontend/src/styles.css die CSS Klasse cardContainer für die Empfehlungen angelegt.
Dieser Name wurde aber bereits bei der Suche verwendet, was dazu führte, dass man bei der Suche nicht mehr scrollen konnte.