### PR TITLE
Make backup creation/import async and bugfixes 

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -5,3 +5,9 @@ symfony console doctrine:migrations:diff
 ```bash
 symfony console doctrine:migrations:migrate
 ```
+
+Run an async worker for backups:
+
+```bash
+php bin/console messenger:consume async -vv
+```

--- a/Backend/config/packages/messenger.yaml
+++ b/Backend/config/packages/messenger.yaml
@@ -26,4 +26,5 @@ framework:
             Symfony\Component\Notifier\Message\SmsMessage: async
 
             # Route your messages to the transports
-            # 'App\Message\YourMessage': async
+            'App\Message\Backup\CreateBackupMessage': async
+            'App\Message\Backup\ImportBackupMessage': async

--- a/Backend/public/index.php
+++ b/Backend/public/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 This file is part of Glotzenheft.
 
@@ -15,6 +16,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+declare(strict_types=1);
 
 use App\Kernel;
 

--- a/Backend/src/Entity/Backup.php
+++ b/Backend/src/Entity/Backup.php
@@ -25,6 +25,7 @@ use App\Repository\BackupRepository;
 use DateTimeInterface;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: BackupRepository::class)]
@@ -64,6 +65,7 @@ class Backup
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     #[Groups(['backup_details'])]
+    #[Context(['datetime_format' => 'Y-m-d H:i:s'])]
     private ?DateTimeInterface $completedAt = null;
 
     public function getId(): ?int

--- a/Backend/src/Entity/Traits/TimestampsTrait.php
+++ b/Backend/src/Entity/Traits/TimestampsTrait.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace App\Entity\Traits;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Attribute\Context;
@@ -53,7 +54,7 @@ trait TimestampsTrait
     {
         if ($this->createdAt === null)
         {
-            $this->createdAt = new DateTimeImmutable();
+            $this->createdAt = $this->getCurrentTime();
         }
     }
 
@@ -72,6 +73,14 @@ trait TimestampsTrait
     #[ORM\PreUpdate]
     public function setUpdatedAtValue(): void
     {
-        $this->updatedAt = new DateTimeImmutable();
+        $this->updatedAt = $this->getCurrentTime();
+    }
+
+    /**
+     * Erstellt ein DateTimeImmutable-Objekt mit der korrekten Zeitzone.
+     */
+    private function getCurrentTime(): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now', new DateTimeZone('Europe/Berlin'));
     }
 }

--- a/Backend/src/Repository/TracklistEpisodeRepository.php
+++ b/Backend/src/Repository/TracklistEpisodeRepository.php
@@ -16,9 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\TracklistEpisode;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -32,28 +35,16 @@ class TracklistEpisodeRepository extends ServiceEntityRepository
         parent::__construct($registry, TracklistEpisode::class);
     }
 
-    //    /**
-    //     * @return TracklistEpisode[] Returns an array of TracklistEpisode objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('t')
-    //            ->andWhere('t.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('t.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
-
-    //    public function findOneBySomeField($value): ?TracklistEpisode
-    //    {
-    //        return $this->createQueryBuilder('t')
-    //            ->andWhere('t.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+    public function findOneByBackupHashAndUser(string $backupHash, User $user): ?TracklistEpisode
+    {
+        return $this->createQueryBuilder('te')
+            ->innerJoin('te.tracklistSeason', 'ts')
+            ->innerJoin('ts.tracklist', 't')
+            ->andWhere('te.backupHash = :hash')
+            ->andWhere('t.user = :user')
+            ->setParameter('hash', $backupHash)
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/Backend/src/Repository/TracklistSeasonRepository.php
+++ b/Backend/src/Repository/TracklistSeasonRepository.php
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace App\Repository;
 
 use App\Entity\TracklistSeason;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -32,28 +33,15 @@ class TracklistSeasonRepository extends ServiceEntityRepository
         parent::__construct($registry, TracklistSeason::class);
     }
 
-    //    /**
-    //     * @return TracklistSeason[] Returns an array of TracklistSeason objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('t')
-    //            ->andWhere('t.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('t.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
-
-    //    public function findOneBySomeField($value): ?TracklistSeason
-    //    {
-    //        return $this->createQueryBuilder('t')
-    //            ->andWhere('t.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+    public function findOneByBackupHashAndUser(string $backupHash, User $user): ?TracklistSeason
+    {
+        return $this->createQueryBuilder('ts')
+            ->innerJoin('ts.tracklist', 't')
+            ->andWhere('ts.backupHash = :hash')
+            ->andWhere('t.user = :user')
+            ->setParameter('hash', $backupHash)
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/Backend/src/Service/Backup/CreateBackupService.php
+++ b/Backend/src/Service/Backup/CreateBackupService.php
@@ -82,7 +82,6 @@ readonly class CreateBackupService
 
             $tracklist->setBackupHash($hash);
             $this->entityManager->persist($tracklist);
-            $this->entityManager->flush();
 
             $backupData[] = $entryData;
         }

--- a/Frontend/src/features/backup/pages/backup-page/backup-page.component.ts
+++ b/Frontend/src/features/backup/pages/backup-page/backup-page.component.ts
@@ -174,10 +174,15 @@ export class BackupPageComponent implements OnInit, OnDestroy {
                     this.messageService.add(
                         getMessageObject(
                             'success',
-                            'Backup erfolgreich erstellt',
+                            'Backup-Erstellung gestartet',
                         ),
                     );
-                    this.loadBackups(); // refresh list immediately
+                    // Warte 5 Sekunden, bevor die Backups neu geladen werden
+                    timer(5000)
+                        .pipe(takeUntil(this.destroy$))
+                        .subscribe(() => {
+                            this.loadBackups();
+                        });
                 },
                 error: (err) => {
                     if (err.status === 401) {
@@ -239,11 +244,8 @@ export class BackupPageComponent implements OnInit, OnDestroy {
                             ),
                         );
 
-                        // Tabelle nur einmal laden, Polling-Start nicht erneut triggern
-                        this.getBackupsUseCase
-                            .execute()
-                            .pipe(takeUntil(this.destroy$))
-                            .subscribe((backups) => (this.backups = backups));
+                        // Lade die Backups neu, um das Polling zu starten
+                        this.loadBackups();
                     }
 
                     // UploadProgress aktualisieren


### PR DESCRIPTION
### Summary
- the backup creation and import are now async
- start async worker with the following command:
- `php bin/console messenger:consume async -vv`
- adjusted frontend page for the async backups

### Bugfixes
- fixed a bug where an import of a very large backup file resulted into an exception (doctrine timeout) after 30 seconds
- fixed a bug where the wrong timezone was used
- fixed a bug where the check for already imported tracklist seasons/episodes didn't include an user check
