### PR TITLE
fix: Synchronize and properly sort TMDB episode and season numbers

### DIFF
--- a/Backend/src/Service/TMDB/TVSeries/TVSeriesSeasonService.php
+++ b/Backend/src/Service/TMDB/TVSeries/TVSeriesSeasonService.php
@@ -97,11 +97,18 @@ readonly class TVSeriesSeasonService
             {
                 $season = (new Season())
                     ->setMedia($media)
-                    ->setTmdbSeasonID($response->getId())
-                    ->setSeasonNumber($response->getSeasonNumber());
+                    ->setTmdbSeasonID($response->getId());
             }
 
             $isSeasonChanged = $isNewSeason;
+
+            $this->setPropertyIfChanged(
+                isChanged: $isSeasonChanged,
+                setter: fn($v) => $season->setSeasonNumber($v),
+                currentValue: $season->getSeasonNumber(),
+                newValue: $response->getSeasonNumber(),
+            );
+
             $this->setPropertyIfChanged(
                 isChanged: $isSeasonChanged,
                 setter: fn($v) => $season->setName($v),
@@ -162,9 +169,15 @@ readonly class TVSeriesSeasonService
                     $season->addEpisode($episode);
                     $episode
                         ->setSeason($season)
-                        ->setTmdbEpisodeID($episodeData->getId())
-                        ->setEpisodeNumber($episodeData->getEpisodeNumber());
+                        ->setTmdbEpisodeID($episodeData->getId());
                 }
+
+                $this->setPropertyIfChanged(
+                    isChanged: $isEpisodeChanged,
+                    setter: fn($v) => $episode->setEpisodeNumber($v),
+                    currentValue: $episode->getEpisodeNumber(),
+                    newValue: $episodeData->getEpisodeNumber(),
+                );
 
                 $this->setPropertyIfChanged(
                     isChanged: $isEpisodeChanged,
@@ -172,24 +185,28 @@ readonly class TVSeriesSeasonService
                     currentValue: $episode->getName(),
                     newValue: $episodeData->getName() ?? '',
                 );
+
                 $this->setPropertyIfChanged(
                     isChanged: $isEpisodeChanged,
                     setter: fn($v) => $episode->setOverview($v),
                     currentValue: $episode->getOverview(),
                     newValue: $episodeData->getOverview() ?? '',
                 );
+
                 $this->setPropertyIfChanged(
                     isChanged: $isEpisodeChanged,
                     setter: fn($v) => $episode->setRuntime($v),
                     currentValue: $episode->getRuntime(),
                     newValue: $episodeData->getRuntime()
                 );
+
                 $this->setPropertyIfChanged(
                     isChanged: $isEpisodeChanged,
                     setter: fn($v) => $episode->setStillPath($v),
                     currentValue: $episode->getStillPath(),
                     newValue: $episodeData->getStillPath()
                 );
+
                 $this->setPropertyIfChanged(
                     isChanged: $isEpisodeChanged,
                     setter: fn($v) => $episode->setAirDate($v),

--- a/Frontend/src/features/media/episodesCOMPONENTS/episode-list/episode-list.component.html
+++ b/Frontend/src/features/media/episodesCOMPONENTS/episode-list/episode-list.component.html
@@ -16,9 +16,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 @if(inpIsWithTracklist()) {
-    @if(episodeList().length > 0) {
+    @if(sortedEpisodeList().length > 0) {
         <div class="episodeDIVWrapper">
-            @for (episode of episodeList(); track $index) {
+            @for (episode of sortedEpisodeList(); track $index) {
                 <div [class]="
                         checkEpisodeInCurrentTracklist(episode.id)
                         ? 'episodeInTracklistDIV'
@@ -53,9 +53,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     }
 }
 @else {
-    @if (episodeList().length > 0) {
+    @if (sortedEpisodeList().length > 0) {
         <div class="episodeDIVWrapper">
-            @for ( episode of episodeList(); track $index) {
+            @for ( episode of sortedEpisodeList(); track $index) {
                 <div class="episodeDIV">
                     <div class="episode-title-container" (click)="openDialog(episode)">
                         <p [pTooltip]="episode.name">E{{ episode.episodeNumber | number: '2.0-0'}}: {{ shortenStringUseCase.execute(episode.name) }}</p>

--- a/Frontend/src/features/media/episodesCOMPONENTS/episode-list/episode-list.component.ts
+++ b/Frontend/src/features/media/episodesCOMPONENTS/episode-list/episode-list.component.ts
@@ -20,6 +20,7 @@ import {
     EventEmitter,
     input,
     InputSignal,
+    computed,
     Output,
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
@@ -67,6 +68,11 @@ export class EpisodeListComponent {
     // input variables
     public episodeList: InputSignal<SeasonEpisode[]> =
         input.required<SeasonEpisode[]>();
+        
+    public sortedEpisodeList = computed(() => {
+        return [...this.episodeList()].sort((a, b) => a.episodeNumber - b.episodeNumber);
+    });
+    
     public inpSelectedTracklist: InputSignal<SeasonTracklist | null> =
         input.required<SeasonTracklist | null>();
     public tracklistSelectionForm: InputSignal<FormGroup | null> =


### PR DESCRIPTION
## Description
This PR fixes an issue where changes to episode or season numbers on TMDB (e.g., swapped episodes) were not being reflected in our application, causing the UI to display episodes out of order.

### 🐛 The Bug
1. **Backend:** The `seasonNumber` and `episodeNumber` were only assigned during the initial creation of the `Season` and `Episode` entities. Subsequent updates from TMDB ignored these fields for existing entities.
2. **Frontend:** The episode list iterated directly through the backend response, which returns episodes in the order they were inserted into the database (by ID), not by their actual `episodeNumber`.

### 🛠️ The Fix
- **Backend (`TVSeriesSeasonService.php`):** Extracted the assignment of `seasonNumber` and `episodeNumber` from the new entity instantiation blocks. They are now evaluated through the `setPropertyIfChanged` method, ensuring any TMDB-side re-numbering is successfully updated in our database. 
- **Frontend (`episode-list.component.ts/html`):** Introduced a `computed` signal (`sortedEpisodeList`) that creates a shallow copy of the episodes and sorts them in ascending order based on the `episodeNumber`. 

### ⚠️ Additional Notes
- **Data Integrity:** Tracklist relations (`TracklistSeason`, `TracklistEpisode`) remain completely intact. Since relationships are strictly tied to internal database IDs (`season_id`, `episode_id`), changing the TMDB `episodeNumber` dynamically does not break user watch states or references.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no API changes)